### PR TITLE
Fix font loading by selecting OS-specific font

### DIFF
--- a/toolbar_example.py
+++ b/toolbar_example.py
@@ -1,20 +1,24 @@
 import random
 import math
 import os
+import platform
 import dearpygui.dearpygui as dpg
 
 # Create context
 dpg.create_context()
 
 # Load font with Cyrillic support without bundling binary files
-font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+font_path = (
+    "C:\\Windows\\Fonts\\arial.ttf"
+    if platform.system() == "Windows"
+    else "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+)
+
 with dpg.font_registry():
     if os.path.exists(font_path):
         default_font = dpg.add_font(font_path, 16)
-    else:
-        default_font = dpg.add_font_default()
-    dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic, parent=default_font)
-dpg.bind_font(default_font)
+        dpg.add_font_range_hint(dpg.mvFontRangeHint_Cyrillic, parent=default_font)
+        dpg.bind_font(default_font)
 
 # Create viewport
 dpg.create_viewport(title="Панель приборов AVO", width=500, height=400)


### PR DESCRIPTION
## Summary
- Load fonts from OS-specific paths for Cyrillic support
- Avoid deprecated add_font_default and bind font only if available

## Testing
- `python -m py_compile toolbar_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2f7656a78832cb2a09ac95bb7f3d2